### PR TITLE
cypress/integration: Add tests for forks

### DIFF
--- a/cypress/integration/productionTests/publicPaths/render/repository/forked.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/repository/forked.spec.ts
@@ -1,0 +1,65 @@
+import { runTestsForDevices } from "../../../../utils";
+import { macbook15ForAppLayout } from "../../../../utils/devices";
+import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
+import {
+  testAboutSection,
+  testCommitSection,
+  testIndexesSection,
+  testPullRequestsSection,
+  testQueryCatalogSection,
+  testRepoHeaderWithBranch,
+  testTablesSection,
+  testViewsSection,
+} from "../../../../utils/sharedTests/repoLeftNav";
+import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
+
+const pageName = "Forked repository page";
+const currentOwner = "automated_testing";
+const currentRepo = "ip-to-country";
+const currentPage = `repositories/${currentOwner}/${currentRepo}`;
+
+describe(`${pageName} renders expected components on different devices`, () => {
+  const beVisible = newShouldArgs("be.visible");
+  const notBeVisible = newShouldArgs("not.be.visible");
+
+  const tests = [
+    newExpectation(
+      "should not find empty repo",
+      "[data-cy=repo-data-table-empty]",
+      notBeVisible,
+    ),
+    newExpectation(
+      "should find repo table data",
+      "[data-cy=repo-data-table]",
+      beVisible,
+    ),
+    newExpectation(
+      "should not find doc markdown",
+      "[data-cy=repo-doc-markdown]",
+      notBeVisible,
+    ),
+    newExpectation(
+      "should display repo data columns",
+      "[data-cy=repo-data-table-columns] > th",
+      newShouldArgs("be.visible.and.have.length", 7),
+    ),
+    testSqlConsole,
+    ...testRepoHeaderWithBranch(currentRepo, currentOwner),
+    newExpectation(
+      "should find forked repo parent detail",
+      "[data-cy=forked-parent-repo-detail]",
+      beVisible,
+    ),
+    testAboutSection,
+    testTablesSection(2, "IPv4ToCountry"),
+    testIndexesSection(2, "IPv4ToCountry"),
+    testViewsSection(0),
+    testQueryCatalogSection(0),
+    testCommitSection(5),
+    testPullRequestsSection(0),
+  ];
+
+  const devices = [macbook15ForAppLayout(pageName, tests)];
+
+  runTestsForDevices({ currentPage, devices });
+});

--- a/cypress/integration/utils/sharedTests/repoLeftNav.ts
+++ b/cypress/integration/utils/sharedTests/repoLeftNav.ts
@@ -23,6 +23,12 @@ const cloneClickFlow = newClickFlow(
   ".popup-overlay",
 );
 
+const forkButtonClickFlow = newClickFlow(
+  "[data-cy=repo-fork-button]",
+  [newExpectation("", "[data-cy=create-fork-modal]", beVisible)],
+  "[data-cy=close-modal]",
+);
+
 export const testRepoHeaderForAll = (
   repoName: string,
   ownerName: string,
@@ -47,6 +53,11 @@ export const testRepoHeaderForAll = (
     "[data-cy=repo-star]",
     beVisible,
   ),
+  newExpectation(
+    "should have repo fork button",
+    "[data-cy=repo-fork-button]",
+    beVisible,
+  ),
   newExpectationWithClickFlows(
     "should have repo clone button",
     "[data-cy=repo-clone-button]",
@@ -60,6 +71,12 @@ export const testRepoHeaderWithBranch = (
   ownerName: string,
 ): Tests => [
   ...testRepoHeaderForAll(repoName, ownerName),
+  newExpectationWithClickFlows(
+    "should open create fork modal on fork button click",
+    "[data-cy=repo-fork-button]",
+    beVisible,
+    [forkButtonClickFlow],
+  ),
   newExpectation(
     "should have repo branch selector",
     "[data-cy=branch-selector]",


### PR DESCRIPTION
Tests for forks (goes with https://github.com/liquidata-inc/ld/pull/5007)

TODO: Once forks are deployed, fork `Liquidata/ip-to-country` to `automated_testing` on prod